### PR TITLE
Improve stopwatch timing accuracy

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,6 +24,7 @@ body {
     background-color: #FFFFFF10;
     border-radius: 0.75rem;
     padding: 1rem;
+    box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 10px;
 }
 .laps {
     flex-grow: 1;
@@ -41,7 +42,6 @@ body {
     margin-left: auto;
     margin-right: auto;
     text-align: center;
-    box-shadow: rgba(0, 0, 0, 0.04) 0px 1px 2px;
 }
 #display {
     font-family: 'Barlow', sans-serif;
@@ -76,10 +76,13 @@ body {
     transition: all 300ms;
     transform: scaleX(0);
 }
+
 .stopwatch-buttons > button:hover::after,
 .stopwatch-buttons > button:focus::after {
     transform: scaleX(1);
     background-color: #FCAB10;
+}
+.stopwatch-buttons > button:hover, .stopwatch-buttons > button:focus {
     opacity: 70%;
 }
 .stopwatch-buttons > button:focus {


### PR DESCRIPTION
Stopwatch slower than expected, particularly when left running in the background/different tab. Might have been due to relying on `setInterval()` to increment the counter? Reworked the `startClock()` and `updateDisplay()`. PR tries to address that. Main changes are:

- Rename `startCounting()` to `startClock()`.
- Rework `startClock()` and `updateDisplay()` to find the time based on Date.now() instead of using own counter.
- Adjusting the `box-shadow` for the stopwatch container.
- Re-add previously removed hover effect from stopwatch buttons.